### PR TITLE
Ensure helpers safe under -u

### DIFF
--- a/src/assert_output.bash
+++ b/src/assert_output.bash
@@ -65,7 +65,7 @@ assert_output() {
   if (( use_stdin )); then
     expected="$(cat -)"
   else
-    expected="$1"
+    expected="${1-}"
   fi
 
   # Matching.

--- a/src/refute_output.bash
+++ b/src/refute_output.bash
@@ -67,7 +67,7 @@ refute_output() {
   if (( use_stdin )); then
     unexpected="$(cat -)"
   else
-    unexpected="$1"
+    unexpected="${1-}"
   fi
 
   if (( is_mode_regexp == 1 )) && [[ '' =~ $unexpected ]] || (( $? == 2 )); then

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -7,6 +7,9 @@ load "${TEST_DEPS_DIR}/bats-support/load.bash"
 # Load library.
 load '../load'
 
+# validate that bats-assert is safe to use under -u
+set -u
+
 : "${status:=}"
 : "${lines:=}"
 : "${output:=}"


### PR DESCRIPTION
Run our own test suite with -u enabled to ensure that the helpers
themselves are safe to use under -u